### PR TITLE
Force Strong Passwords at Login

### DIFF
--- a/changes/7.canada.feature
+++ b/changes/7.canada.feature
@@ -1,0 +1,1 @@
+Added the capability to enforce strong passwords at login.

--- a/ckanext/security/schema.py
+++ b/ckanext/security/schema.py
@@ -11,6 +11,9 @@ from ckan.logic.validators import (
 from ckanext.security.validators import (
     user_password_validator, old_username_validator, ensure_str
 )
+# (canada fork only): reset throttle after successful authentication
+# TODO: upstream contrib??
+from ckan.logic.schema import validator_args
 
 # The main purpose of this file is to modify CKAN's user-related schemas, and
 # to replace the default password validators everywhere. We are also replacing
@@ -75,3 +78,14 @@ def default_update_user_schema():
                           ignore_missing, ensure_str]
 
     return schema
+
+
+# (canada fork only): reset throttle after successful authentication
+# TODO: upstream contrib??
+@validator_args
+def force_strong_password_at_login_schema(not_empty, name_validator,
+        user_name_validator, unicode_safe,
+        user_password_validator, old_username_validator):
+    return {'name': [not_empty, name_validator, user_name_validator,
+                     unicode_safe, old_username_validator],
+            'password': [not_empty, unicode_safe, user_password_validator],}

--- a/ckanext/security/validators.py
+++ b/ckanext/security/validators.py
@@ -32,10 +32,13 @@ def user_password_validator(key, data, errors, context):
         nzism_compliant = asbool(config.get('ckanext.security.nzism_compliant_passwords', True))
 
         username = data.get(('name',), None)
-        password1 = data.get(('password1',), None)
-        password2 = data.get(('password2',), None)
+        password_fields = [
+            data.get(('password',), None),
+            data.get(('password1',), None),
+            data.get(('password2',), None),
+        ]
 
-        if username == password1 or username == password2:
+        if username in password_fields:
             errors[key].append(_(SAME_USERNAME_PASSWORD_ERROR))
 
         if len(value) < min_password_length:


### PR DESCRIPTION
feat(logic): force strong password;

- Force strong passwords at login.

As discussed, this is really really hard to do in the CKAN 2.9 app stack with repoze. So instead of mucking around and creating really bad and wild things for 2.9, we are just going to do this in 2.10. This should be fine with our timelines of everything.

TODO: get revised wording for the flash error of weak password. Will get biz to test it on the Test server and they can come up with something better.